### PR TITLE
[DO NOT MERGE] - Needs support for the following key bindings

### DIFF
--- a/ThroughTheEyes/FPStateFloating.cs
+++ b/ThroughTheEyes/FPStateFloating.cs
@@ -82,31 +82,31 @@ namespace FirstPerson
 				//************Rotation************
 				Quaternion manualRotation = Quaternion.identity;
 				Vector3 commandedManualRotation = Vector3.zero;
-				if (GameSettings.YAW_LEFT.GetKey (false)) {
+				if (GameSettings.YAW_LEFT.GetKey (false)) { // || GameSettings.EVA_yaw_left || GameSettings.axis_EVA_yaw
 					manualRotation = manualRotation * Quaternion.AngleAxis ((float)(-(double)eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.up);
 					commandedManualRotation -= eva.transform.up;
 					//KSPLog.print ("YAW LEFT");
-				} else if (GameSettings.YAW_RIGHT.GetKey (false)) {
+				} else if (GameSettings.YAW_RIGHT.GetKey (false)) { // || GameSettings.EVA_yaw_right || GameSettings.axis_EVA_yaw
 					manualRotation = manualRotation * Quaternion.AngleAxis ((float)((double)eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.up);
 					commandedManualRotation += eva.transform.up;
 					//KSPLog.print ("YAW RIGHT");
 				}
 
-				if (GameSettings.PITCH_UP.GetKey (false)) {
+				if (GameSettings.PITCH_UP.GetKey (false)) { // GameSettings.axis_EVA_pitch
 					manualRotation = manualRotation * Quaternion.AngleAxis ((float)(-(double)eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.right);
 					commandedManualRotation -= eva.transform.right;
 					//KSPLog.print ("PITCH UP");
-				} else if (GameSettings.PITCH_DOWN.GetKey (false)) {
+				} else if (GameSettings.PITCH_DOWN.GetKey (false)) { // GameSettings.axis_EVA_pitch
 					manualRotation = manualRotation * Quaternion.AngleAxis ((float)((double)eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.right);
 					commandedManualRotation += eva.transform.right;
 					//KSPLog.print ("PITCH DOWN");
 				}
 
-				if (GameSettings.ROLL_RIGHT.GetKey (false)) {
+				if (GameSettings.ROLL_RIGHT.GetKey (false)) { // GameSettings.axis_EVA_roll
 					manualRotation = manualRotation * Quaternion.AngleAxis ((float)(-(double)eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.forward);
 					commandedManualRotation -= eva.transform.forward;
 					//KSPLog.print ("ROLL RIGHT");
-				} else if (GameSettings.ROLL_LEFT.GetKey (false)) {
+				} else if (GameSettings.ROLL_LEFT.GetKey (false)) { // GameSettings.axis_EVA_roll
 					manualRotation = manualRotation * Quaternion.AngleAxis ((float)((double)eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.forward);
 					commandedManualRotation += eva.transform.forward;
 					//KSPLog.print ("ROLL LEFT");
@@ -173,31 +173,31 @@ namespace FirstPerson
 
 				//************Translation************
 				Vector3 manualTranslation = Vector3.zero;
-				if (GameSettings.TRANSLATE_LEFT.GetKey (false)) {
+				if (GameSettings.TRANSLATE_LEFT.GetKey (false)) { // GameSettings.EVA_Pack_left || GameSettings.axis_EVA_translate_x
 					manualTranslation += Vector3.left;
 					//manualRotation = manualRotation * Quaternion.AngleAxis((float) (-(double) eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.up);
 					//KSPLog.print ("TRANSLATE LEFT");
-				} else if (GameSettings.TRANSLATE_RIGHT.GetKey (false)) {
+				} else if (GameSettings.TRANSLATE_RIGHT.GetKey (false)) { // GameSettings.EVA_Pack_right || GameSettings.axis_EVA_translate_x
 					manualTranslation += Vector3.right;
 					//manualRotation = manualRotation * Quaternion.AngleAxis((float) ((double) eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.up);
 					//KSPLog.print ("TRANSLATE RIGHT");
 				}
 
-				if (GameSettings.TRANSLATE_UP.GetKey (false)) {
+				if (GameSettings.TRANSLATE_UP.GetKey (false)) { // GameSettings.EVA_Pack_up || GameSettings.axis_EVA_translate_y
 					manualTranslation += Vector3.up;
 					//manualRotation = manualRotation * Quaternion.AngleAxis((float) (-(double) eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.right);
 					//KSPLog.print ("TRANSLATE UP");
-				} else if (GameSettings.TRANSLATE_DOWN.GetKey (false)) {
+				} else if (GameSettings.TRANSLATE_DOWN.GetKey (false)) { // GameSettings.EVA_Pack_down || GameSettings.axis_EVA_translate_y
 					manualTranslation += Vector3.down;
 					//manualRotation = manualRotation * Quaternion.AngleAxis((float) ((double) eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.right);
 					//KSPLog.print ("TRANSLATE DOWN");
 				}
 
-				if (GameSettings.TRANSLATE_FWD.GetKey (false)) {
+				if (GameSettings.TRANSLATE_FWD.GetKey (false)) { // GameSettings.EVA_Pack_forward || GameSettings.axis_EVA_translate_z
 					manualTranslation += Vector3.forward;
 					//manualRotation = manualRotation * Quaternion.AngleAxis((float) (-(double) eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.forward);
 					//KSPLog.print ("TRANSLATE RIGHT");
-				} else if (GameSettings.TRANSLATE_BACK.GetKey (false)) {
+				} else if (GameSettings.TRANSLATE_BACK.GetKey (false)) { // GameSettings.EVA_Pack_back || GameSettings.axis_EVA_translate_z
 					manualTranslation += Vector3.back;
 					//manualRotation = manualRotation * Quaternion.AngleAxis((float) ((double) eva.turnRate * Mathf.Rad2Deg) * Time.deltaTime, eva.transform.forward);
 					//KSPLog.print ("TRANSLATE LEFT");


### PR DESCRIPTION
Hey, I hope somebody is still supporting this awesome mod!!

I'm just a full stack web developer and couldn't help to check the code to see if I could fix/add the missing key bindings for the EVA buttons configurations.

I know nothing about Unity (just a little c#), and have no idea how to compile this, but I added some comments next to the lines I think should be modified to support the key bindings for the EVA input section specifically for joystick since I'm playing with a joystick. I already extracted the GameSettings constants and double checked that they're the right ones to add. 

For the joystick axis settings, I don't know how you'd differentiate between left / right, up / down, etc, but I'm guessing it should be pretty straight forward.

Please let me know if you have time to do this or maybe point me to somebody who can? 
Otherwise I guess I'll have to learn some Unity.

Here is a picture of the inputs I'm talking about:
![eva-input](https://github.com/linuxgurugamer/Through-The-Eyes/assets/5598360/a49698bb-f79b-4676-afe4-44432b620f30)

cc: @linuxgurugamer 