### PR TITLE
Fix rendering artifacts with newer versions of deferred + scatterer

### DIFF
--- a/ThroughTheEyes/FirstPersonCameraManager.cs
+++ b/ThroughTheEyes/FirstPersonCameraManager.cs
@@ -126,6 +126,12 @@ namespace FirstPerson
 				   ) {
 					renderer.enabled = enable;
 				}
+				else if (renderer.sharedMaterial.name.StartsWith("Deferred/DummyForwardShader"))
+				{
+					// Deferred adds a dummy mesh here to force certain render passes to happen
+					// https://github.com/LGhassen/Deferred/blob/328104c6ef9f579594c7c9829a16cf91e65444d5/DeferredKSP/Utils/ForwardRenderingCompatibility.cs
+					// https://github.com/LGhassen/Scatterer/issues/238
+				}
 				else
 				{
 					const int LAYER_EVA = 17;


### PR DESCRIPTION
-deferred adds a dummy mesh to the flight camera to make sure that certain render passes aren't skipped.  Our code that attaches the flight camera to the eva kerbal and then changes the layers on the kerbal was inadvertently changing the layer of that dummy mesh, so it wasn't getting rendered by the flight camera anymore.