### PR TITLE
Fix EVABoundFix NRE loop on null KFSM state (#19)

### DIFF
--- a/ThroughTheEyes/EVABoundFix.cs
+++ b/ThroughTheEyes/EVABoundFix.cs
@@ -9,8 +9,49 @@ namespace FirstPerson
 	{
 		public static void Hook(KerbalEVA eva)
 		{
+			// Validate the KFSM state before constructing EVABoundFix. The
+			// constructor dereferences eva.On_bound_fall, eva.On_bound_land
+			// and eva.st_bound_fl directly; if any is still null (some custom
+			// EVA suits, partially-loaded vessels, or particular mod combos)
+			// the resulting NullReferenceException is logged at frame rate
+			// because FirstPersonEVA.Update() retries Hook every frame.
+			if (eva == null)
+			{
+				LogSkipOnce("eva is null");
+				return;
+			}
+			if (eva.vessel == null)
+			{
+				LogSkipOnce("eva.vessel is null");
+				return;
+			}
+			if (eva.On_bound_fall == null)
+			{
+				LogSkipOnce("eva.On_bound_fall is null");
+				return;
+			}
+			if (eva.On_bound_land == null)
+			{
+				LogSkipOnce("eva.On_bound_land is null");
+				return;
+			}
+			if (eva.st_bound_fl == null)
+			{
+				LogSkipOnce("eva.st_bound_fl is null");
+				return;
+			}
+
 			//The reference is held by the replacement delegate.
 			EVABoundFix temp = new EVABoundFix(eva);
+		}
+
+		// Dedup skip log messages so a persistently-broken EVA state does
+		// not spam Player.log at frame rate.
+		static readonly HashSet<string> _seenSkipReasons = new HashSet<string>();
+		static void LogSkipOnce(string reason)
+		{
+			if (_seenSkipReasons.Add(reason))
+				UnityEngine.Debug.Log("[ThroughTheEyes] EVABoundFix.Hook skipped: " + reason);
 		}
 
 		KerbalEVA myeva;


### PR DESCRIPTION
## Summary

Fixes #19.

`EVABoundFix.Hook` unconditionally constructs a new `EVABoundFix` whose private constructor dereferences `eva.On_bound_fall`, `eva.On_bound_land` and `eva.st_bound_fl` directly:

```csharp
myeva.On_bound_fall.OnCheckCondition = Replacement_On_bound_fall_OnCheckCondition;
myeva.On_bound_land.OnCheckCondition = Replacement_On_bound_land_OnCheckCondition;
// ...
for (int i = 0; i < myeva.st_bound_fl.StateEvents.Count; ++i) { ... }
```

Under some conditions — certain custom EVA suits, partially-loaded vessels, or specific mod combinations — one or more of those KFSM fields are still `null` when `Hook` is called. The resulting `NullReferenceException` is not caught.

Because `FirstPersonEVA.Update()` calls `Hook` every frame whenever it detects a fresh `KerbalEVA`, a single broken state produces an NRE at ~60 messages per second, flooding `Player.log` (the report in #19 measured **~250 NREs over ~5 seconds**) and degrading frame time.

## Fix

Validate `eva`, `eva.vessel`, and the three KFSM fields **before** constructing `EVABoundFix`. If any is null, log the reason once and return cleanly. The mod silently skips `Hook` for that particular EVA — the fields will populate later in normal cases and `Hook` will succeed on the next call.

```csharp
if (eva.On_bound_fall == null) { LogSkipOnce("eva.On_bound_fall is null"); return; }
// ...
EVABoundFix temp = new EVABoundFix(eva);
```

A small `HashSet<string>` dedups the skip log so a persistent problem logs exactly **once per distinct reason** instead of every frame. No new allocations on the happy path.

## Verification

Tested locally on KSP 1.12.5 with the equivalent change applied via an external Harmony Prefix patch ([TTE_Fix](https://github.com/edujoliver/TTE-Fix)). The previously continuous NRE flood disappeared; `Player.log` now contains at most one line per broken state, and the per-frame time spent in exception handling is eliminated.

## Notes

- `+41 lines` total, most of which is comment + the per-field check block.
- No behavior change on the happy path: when all fields are non-null, the original constructor runs as before.
- No allocations or work added when `Hook` succeeds (the `HashSet.Add` only fires on the skip path).